### PR TITLE
Fix Uint8Array.toString() warning with newish gjs

### DIFF
--- a/people.js
+++ b/people.js
@@ -1,3 +1,4 @@
+const ByteArray = imports.byteArray;
 const GLib = imports.gi.GLib;
 const Gio = imports.gi.Gio;
 const Lang = imports.lang;
@@ -75,7 +76,7 @@ var People = new Lang.Class({
         }
 
         try {
-            rawPeople = JSON.parse(contents);
+            rawPeople = JSON.parse(ByteArray.toString(contents));
         } catch (e) {
             log('Error parsing %s: %s'.format(this._path, e));
             this._getPeopleOriginalCB({error: 'There was an error parsing people.json file'});


### PR DESCRIPTION
With gjs 1.56.2 (and possibly older versions), the previous code emitted this warning (wrapped for legibility):

    Some code called array.toString() on a Uint8Array instance.
    Previously this would have interpreted the bytes of the array as a
    string, but that is nonstandard. In the future this will return the
    bytes as comma-separated digits. For the time being, the old
    behavior has been preserved, but please fix your code anyway to
    explicitly call ByteArray.toString(array).

    (Note that array.toString() may have been called implicitly.)

    0 _getPeopleCB() ["/sysroot/home/wjt/.local/share/gnome-shell/extensions/timezone@jwendell/people.js":78]
    1 wrapper() ["resource:///org/gnome/gjs/modules/_legacy.js":82]
    2 wrapper() ["self-hosted":979]

In this case, array.toString() is indeed being called implicitly.

The `contents` out parameter of `g_file_load_contents_finish()` is [annotated][0] as [element-type guint8][array length=length], which is correct: the file is arbitrary bytes. If the bytes happen to not be valid UTF-8, this new code emits:

    Error parsing file:///sysroot/home/wjt/people.json: TypeError: malformed UTF-8 character sequence at offset 4

[0]: https://developer.gnome.org/gio/2.60/GFile.html#g-file-load-contents-finish