### PR TITLE
Declared compatibility with Gnome 41

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -1,5 +1,5 @@
 {
-	"shell-version": ["3.32", "40"],
+	"shell-version": ["3.32", "41"],
 	"uuid": "timezone@jwendell",
 	"description": "See people with their timezones from the Shell",
 	"name": "Timezone",


### PR DESCRIPTION
Hi there, Fedora 35, expected to release on  November 2, 2021 uses Gnome 41

```
15:45 $ rpm -qa gnome-shell
gnome-shell-41.0-4.fc35.x86_64
```

The beta is already available, I've just checked the extension and it works fine (despite I haven't checked any explicit release notes from the project).


See screenshot

![Screenshot from 2021-10-28 15-41-51](https://user-images.githubusercontent.com/1520602/139268798-a6203f31-592f-496e-80bc-292a30d43aeb.png)

Would you consider merging this?
