### PR TITLE
Added gitlab avatar support

### DIFF
--- a/schema-people.json
+++ b/schema-people.json
@@ -29,6 +29,10 @@
 				"type": "string",
 				"description": "Gravatar ID (person's email)"
 			},
+			"gitlab": {
+				"type": "string",
+				"description": "GitLab avatar (person's email)"
+			},
 			"github": {
 				"type": "string",
 				"description": "GitHub ID"


### PR DESCRIPTION
Added GitLab avatar support, merely any addition to the logic but APIs.
Only works for **gitlab.com** (**No self-hosting GitLab** avatar support), self-hosting may be using GTK's `prefs` settings.

Fixes #36 

Signed-off-by: Savitoj Singh <savsingh@redhat.com>