### PR TITLE
#48: Fix label visibility by defining text color

### DIFF
--- a/stylesheet.css
+++ b/stylesheet.css
@@ -30,6 +30,7 @@
 .tzi-avatar-name-box {
     background-color: #393f3f;
     font-size: 8pt;
+    color: #d3d3d3;
 }
 
 .tzi-avatar-name {


### PR DESCRIPTION
Fixes #48 (alternative to PR at #50)

Bug visible on Ubuntu 20.04.3 // Gnome 3.36.8:
![Screenshot from 2022-02-11 09-56-27](https://user-images.githubusercontent.com/608958/153564067-28513a7d-7186-4f64-8d67-f406e648c344.png)

With the fix:
![Screenshot from 2022-02-11 09-56-54](https://user-images.githubusercontent.com/608958/153564112-dacc6da9-54c8-4ec3-9693-f091a2337c15.png)

Local workaround: apply the change to ~/.local/share/gnome-shell/extensions/timezone@jwendell/stylesheet.css
