### PR TITLE
Fix non-working file picker in TimezoneExtensionPrefsWidget4

### DIFF
--- a/prefs4.js
+++ b/prefs4.js
@@ -44,7 +44,7 @@ var TimezoneExtensionPrefsWidget4 = new GObject.Class({
             secondary_icon_tooltip_text: "Pick a file using a file chooser"
         });
         this._entry.connect("icon-release", Lang.bind(this, function() {
-            this._chooser.transient_for = this.get_root()
+            this._chooser.transient_for = this.box.get_root()
             this._chooser.show();
         }));
 


### PR DESCRIPTION
The call to get_root() to set the GtkWindow the file picker should be transient for in TimezoneExtensionPrefsWidget4 needs to be done over a GtkWidget, not a GObject, so call it over this.box.

This fixes the file picker to select a custom path for the people.json file in the preferences dialog.

Closes #59