### PR TITLE
fix: destroy old mainBox on UI rebuild to prevent actor leak and crash loop

### DIFF
--- a/indicator.js
+++ b/indicator.js
@@ -183,7 +183,8 @@ class TimezoneIndicator extends PanelMenu.Button {
 
     _createUI() {
         if (this._mainBox) {
-            this._item.remove_child(this._mainBox);
+            this._mainBox.destroy();
+            this._mainBox = null;
         }
 
         this._mainBox = new St.BoxLayout({vertical: true});


### PR DESCRIPTION
## Problem

My syslog got huge (127GB) filled with:

```
May 18 08:00:00 precision3591 gnome-shell[5163]: Attempting to run a JS callback during garbage collection. This is most likely caused by destroying a Clutter actor or GTK widget with ::destroy signal connected, or using the destroy(), dispose(), or remove() vfuncs. Because it would crash the application, it has been blocked.
May 18 08:00:00 precision3591 gnome-shell[5163]: The offending callback was SourceFunc().
May 18 08:00:00 precision3591 gnome-shell[5163]: Object .Gjs_ui_popupMenu_PopupBaseMenuItem (0x57a6deb72660), has been already disposed — impossible to access it. This might be caused by the object having been destroyed from C code using something such as destroy(), dispose(), or remove() vfuncs.
May 18 08:00:00 precision3591 gnome-shell[5163]: == Stack trace for context 0x57a6dbfb6170 ==
May 18 08:00:00 precision3591 gnome-shell[5163]: #0   57a6e7ac3fa8 i   /home/[username]/.local/share/gnome-shell/extensions/timezone@jwendell/indicator.js:176 (3d7bd1892920 @ 55)
May 18 08:00:00 precision3591 gnome-shell[5163]: #1   57a6e7ac3f00 i   /home/[username]/.local/share/gnome-shell/extensions/timezone@jwendell/indicator.js:183 (3d7bd1892920 @ 220)
May 18 08:00:00 precision3591 gnome-shell[5163]: #2   7ffd0a375970 b   self-hosted:1178 (31229bdb0a10 @ 454)
```

It continued until my computer had no more disk space.

When `_createUI()` is called repeatedly — triggered by the `World` object's `changed` signal (e.g. when GitHub/Gravatar avatar data arrives) or by monitor resolution changes — the previous `_mainBox` was only removed from its parent with `remove_child()` but **never destroyed**.

This leaks the entire previous UI subtree on every rebuild: all `St.BoxLayout`, `St.Label`, and `St.Button` actors, along with their signal connections, accumulate in memory as disposed-but-still-referenced objects.

GJS then attempts to invoke callbacks on these disposed objects during garbage collection, which triggers the following crash loop logged to syslog:

```
gnome-shell[5163]: Attempting to run a JS callback during garbage collection. This is most
likely caused by destroying a Clutter actor or GTK widget with ::destroy signal connected...
gnome-shell[5163]: The offending callback was SourceFunc().
```

This loop can repeat hundreds of millions of times, filling the syslog to tens or hundreds of gigabytes and exhausting disk space.

## Fix

Replace `this._item.remove_child(this._mainBox)` with `this._mainBox.destroy()` in `_createUI()`. The `destroy()` call both removes the actor from its parent **and** frees it along with all its children and signal connections, preventing the leak entirely.

`_mainBox` is also nulled out immediately after `destroy()` to avoid any dangling reference.

## Change

```diff
 _createUI() {
     if (this._mainBox) {
-        this._item.remove_child(this._mainBox);
+        this._mainBox.destroy();
+        this._mainBox = null;
     }
```